### PR TITLE
Update URLs to NGI instead of SciLifeLab

### DIFF
--- a/contributing/index.html
+++ b/contributing/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         

--- a/installation/index.html
+++ b/installation/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         

--- a/report_ign_sample_report/index.html
+++ b/report_ign_sample_report/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         

--- a/report_project_report/index.html
+++ b/report_project_report/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         

--- a/usage/index.html
+++ b/usage/index.html
@@ -94,7 +94,7 @@
                 </li>
                 
                 <li>
-                    <a href="https://github.com/SciLifeLab/ngi_reports/">
+                    <a href="https://github.com/NationalGenomicsInfrastructure/ngi_reports/">
                         
                             <i class="fa fa-github"></i>
                         


### PR DESCRIPTION
Updated URLs in docs due to organisation change of repo..