### PR TITLE
Fixed snpEff part of ign same report, made node determination better

### DIFF
--- a/data/report_templates/ign_sample_report.md
+++ b/data/report_templates/ign_sample_report.md
@@ -42,7 +42,7 @@ Pooling Reagent
 {% endif %}{% if sample.flowcells %}
 Flow Cells
 :   {% for fc in sample.flowcells %}`{{ fc.id }}`
-    
+
     {% endfor %}
 {% endif %}
 
@@ -119,7 +119,7 @@ this in the histogram below. This was done using the
 ## Distribution of reads by GC content
 Library preparation and sequencing alignment can be affected by differences in
 GC content. Here, we plot the proportions of the library reads at each GC
-content. The red dotted line shows the profile for the reference genome. 
+content. The red dotted line shows the profile for the reference genome.
 This data was calculated using [QualiMap](http://qualimap.bioinfo.cipf.es/)
 and plotted with an [NGI script](https://github.com/SciLifeLab/visualizations).
 
@@ -129,40 +129,40 @@ and plotted with an [NGI script](https://github.com/SciLifeLab/visualizations).
 
 {% if sample.snpeff %}
 # Variants
-
+{% if sample.snpeff.change_rate %}
 Change Rate
 :   {{ sample.snpeff.change_rate }}
-
+{% endif %}{% if sample.snpeff.total_snps %}
 Total SNPs
 :   {{ sample.snpeff.total_snps }}
-
+{% endif %}{% if sample.snpeff.homotypic_snps %}
 Homotypic SNPs
 :   {{ sample.snpeff.homotypic_snps }}
-
+{% endif %}{% if sample.snpeff.heterotypic_snps %}
 Heterotypic SNPs
 :   {{ sample.snpeff.heterotypic_snps }}
-
+{% endif %}{% if sample.snpeff.TsTv_ratio %}
 Ts/Tv Ratio
 :   {{ sample.snpeff.TsTv_ratio }}
-
+{% endif %}{% if sample.snpeff.synonymous_SNPs %}
 Synonymous SNPs
 :   {{ sample.snpeff.synonymous_SNPs }}
-
+{% endif %}{% if sample.snpeff.nonsynonymous_SNPs %}
 Non-Synonymous SNPs
 :   {{ sample.snpeff.nonsynonymous_SNPs }}
-
+{% endif %}{% if sample.snpeff.stops_gained and sample.snpeff.stops_lost %}
 Stop Gained / Lost
 :   {{ sample.snpeff.stops_gained }} / {{ sample.snpeff.stops_lost }}
-
+{% endif %}{% if sample.snpeff.percent_missense_SNPs and sample.snpeff.missense_SNPs %}
 Missense SNPs
 :   {{ sample.snpeff.percent_missense_SNPs }}  -   {{ sample.snpeff.missense_SNPs }}
-
+{% endif %}{% if sample.snpeff.percent_nonsense_SNPs and sample.snpeff.nonsense_SNPs %}
 Nonsense SNPs
 :   {{ sample.snpeff.percent_nonsense_SNPs }}  -   {{ sample.snpeff.nonsense_SNPs }}
-
+{% endif %}{% if sample.snpeff.percent_silent_SNPs and sample.snpeff.silent_SNPs %}
 Silent SNPs
 :   {{ sample.snpeff.percent_silent_SNPs }}  -   {{ sample.snpeff.silent_SNPs }}
-
+{% endif %}
 Different effects can be attributed to each SNP depending on where it occurs.
 Here we have used the [snpEff](http://snpeff.sourceforge.net/) tool to
 categorise and count different effects. The results were plotted with an
@@ -173,6 +173,3 @@ categorise and count different effects. The results were plotted with an
 See the `snpEff_summary.html` report in your delivery folder for more details.
 
 {% endif %}
-
-
-

--- a/data/report_templates/ign_sample_report.md
+++ b/data/report_templates/ign_sample_report.md
@@ -72,10 +72,12 @@ GC Content
 
 See below for more information about coverage and insert size. The
 `qualimapReport.html` report in your delivery folder contains additional library
-statistics. Note that the duplication rate above is calculated using
+statistics.
+{% if sample.duplication_rate %}Note that the duplication rate above is calculated using
 [Picard Mark Duplicates](http://broadinstitute.github.io/picard/command-line-overview.html#MarkDuplicates).
 Qualimap calculates duplicates differently and the figure in
 the report will be different to the Picard result..
+{% endif %}
 
 ## Distribution of sequencing coverage
 Calculating the coverage of a genome tells you how much information you have

--- a/data/report_templates/ign_sample_report.md
+++ b/data/report_templates/ign_sample_report.md
@@ -168,7 +168,7 @@ Here we have used the [snpEff](http://snpeff.sourceforge.net/) tool to
 categorise and count different effects. The results were plotted with an
 [NGI script](https://github.com/SciLifeLab/visualizations).
 
-![Insert Sizes]({{ plots.snpEFf_plot }})\
+![snpEff - Effect Regions]({{ plots.snpEFf_plot }})\
 
 See the `snpEff_summary.html` report in your delivery folder for more details.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -58,6 +58,11 @@ Obviously, if you're working at the Uppsala NGI node, change the `ngi_node` to
 `uppsala` instead of `stockholm`. The `organism_names` section should have
 reference id key - text pairs. This is used to make the report more verbose.
 
+**Note:** In production, `ngi_reports` is run as the `funk` user by both
+Stockholm and Uppsala nodes. Here, the config file should _not_ contain the
+`ngi_node` option. The code will try to guess the node from Piper XML files
+or can be specified with the `--ngi_node` command line parameter.
+
 ## Bash Commands
 To use `ngi_reports` from the command line easily, there are some bash commands
 that you need. These are written into a bash script to make life easy - you need to add

--- a/ngi_reports/common/__init__.py
+++ b/ngi_reports/common/__init__.py
@@ -19,9 +19,6 @@ class BaseReport(object):
         self.LOG = LOG
         self.working_dir = working_dir
 
-        # Setup
-        self.ngi_node = config.get('ngi_reports', 'ngi_node')
-
         # Standalone fields
         self.date_format = "%Y-%m-%d"
         self.creation_date = datetime.now().strftime(self.date_format)

--- a/ngi_reports/common/__init__.py
+++ b/ngi_reports/common/__init__.py
@@ -12,22 +12,22 @@ class BaseReport(object):
     """ Base report object class. Provides some common fields and helper
     methods to be used by all report types.
     """
-    
+
     def __init__(self, config, LOG, working_dir, **kwargs):
         # Incoming handles
         self.config = config
         self.LOG = LOG
         self.working_dir = working_dir
-    
+
         # Setup
         self.ngi_node = config.get('ngi_reports', 'ngi_node')
-    
+
         # Standalone fields
         self.date_format = "%Y-%m-%d"
         self.creation_date = datetime.now().strftime(self.date_format)
         self.organism_names = config._sections.get('organism_names', {})
-    
-    
+
+
     def parse_piper_xml(self):
         """ Parses the XML setup files that Piper uses
         """
@@ -44,8 +44,8 @@ class BaseReport(object):
             for file in os.listdir(setup_dir):
                 if file.endswith(".xml"):
                     xml_files.append(os.path.join(setup_dir, file))
-        
-        
+
+
         self.LOG.info('Found {} Piper setup XML file{}..'.format(len(xml_files), '' if len(xml_files) == 1 else 's'))
         for xml_fn in xml_files:
             try:
@@ -56,7 +56,7 @@ class BaseReport(object):
                 pass
             else:
                 run = raw_xml['project']
-                # Essential fields   
+                # Essential fields
                 try:
                     project['id'] = run['metadata']['name']
                     project['ngi_name'] = run['metadata']['name']
@@ -75,15 +75,13 @@ class BaseReport(object):
                 except KeyError as e:
                     self.LOG.warning('Could not find essential key in sample XML file: '+e.message)
                     pass
-        
-                # Non-Essential fields   
+
+                # Non-Essential fields
                 try:
-                    project['UPPMAXid'] = run['metadata']['uppmaxprojectid']
                     project['sequencing_platform'] = run['metadata']['platform']
                     project['ref_genome'] = os.path.basename(run['metadata']['reference'])
                 except KeyError as e:
                     self.LOG.warning('Could not find optional key in sample XML file: '+e.message)
                     pass
-        
-        return {'project': project, 'samples': samples}
 
+        return {'project': project, 'samples': samples}

--- a/ngi_reports/common/config.py
+++ b/ngi_reports/common/config.py
@@ -11,7 +11,7 @@ def load_config(config_file=None):
     try:
         if not config_file:
             config_file = os.path.join(os.environ.get('HOME'), '.ngi_config', 'ngi_reports.conf')
-        config = ConfigParser.SafeConfigParser()
+        config = ConfigParser.SafeConfigParser({'ngi_node': 'unknown'})
         with open(config_file) as f:
             config.readfp(f)
         return config

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -147,22 +147,18 @@ class CommonReport(ngi_reports.common.BaseReport):
                     for line in fh:
                         line = line.strip()
 
-                        # Number_of_variants_before_filter, 4004647
                         if line[:33] == 'Number_of_variants_before_filter,':
                             snpEff['total_snps'] = '{:,}'.format(int(line[34:]))
 
-                        # Number_of_variants_before_filter, 4004647
                         if line[:13] == 'Change_rate ,':
                             snpEff['change_rate'] = '1 change per {:,} bp'.format(int(line[14:]))
 
-                        # Type, Total, Homo, Hetero
-                        # SNP , 4004647 , 1491592 , 2513055
-                        if line[:5] == 'SNP ,':
-                            sections = line.split(',')
-                            snpEff['homotypic_snps'] = '{:,}'.format(int(sections[2].strip()))
-                            snpEff['heterotypic_snps'] = '{:,}'.format(int(sections[3].strip()))
+                        if line[:5] == 'Het ,':
+                            snpEff['heterotypic_snps'] = '{:,}'.format(int(line[6:]))
 
-                        # Type , Count , Percent
+                        if line[:5] == 'Hom ,':
+                            snpEff['homotypic_snps'] = '{:,}'.format(int(line[6:]))
+
                         if line[:10] == 'MISSENSE ,':
                             sections = line.split(',')
                             pc = sections[2].strip()
@@ -184,6 +180,30 @@ class CommonReport(ngi_reports.common.BaseReport):
                             snpEff['percent_silent_SNPs'] = '{:.1f}%'.format(pc)
                             snpEff['silent_SNPs'] = '{:,}'.format(int(sections[1].strip()))
 
+                        if line[:20] == 'synonymous_variant ,':
+                            sections = line.split(',')
+                            synonymous_SNPs += int(sections[1].strip())
+
+                        if line[:13] == 'stop_gained ,':
+                            sections = line.split(',')
+                            snpEff['stops_gained'] = '{:,}'.format(int(sections[1].strip()))
+
+                        if line[:11] == 'stop_lost ,':
+                            sections = line.split(',')
+                            snpEff['stops_lost'] = '{:,}'.format(int(sections[1].strip()))
+
+                        if line[:13] == 'Ts_Tv_ratio ,':
+                            snpEff['TsTv_ratio'] = '{:.3f}'.format(float(line[14:]))
+                            
+
+                        # ALTERNATIVE BLOCKS FOR OLDER VERSION OF SNPEFF
+                        # Type, Total, Homo, Hetero
+                        # SNP , 4004647 , 1491592 , 2513055
+                        if line[:5] == 'SNP ,':
+                            sections = line.split(',')
+                            snpEff['homotypic_snps'] = '{:,}'.format(int(sections[2].strip()))
+                            snpEff['heterotypic_snps'] = '{:,}'.format(int(sections[3].strip()))
+
                         if line[:10] == 'SYNONYMOUS':
                             sections = line.split(',')
                             synonymous_SNPs += int(sections[1].strip())
@@ -200,9 +220,6 @@ class CommonReport(ngi_reports.common.BaseReport):
                             sections = line.split(',')
                             snpEff['stops_lost'] = '{:,}'.format(int(sections[1].strip()))
 
-                        # Ts_Tv_ratio , 1.989511
-                        if line[:13] == 'Ts_Tv_ratio ,':
-                            snpEff['TsTv_ratio'] = '{:.3f}'.format(float(line[14:]))
 
             except:
                 self.LOG.error("Something went wrong with parsing the snpEff results")
@@ -226,14 +243,10 @@ class CommonReport(ngi_reports.common.BaseReport):
             picard_metrics_fn = os.path.realpath(os.path.join(self.working_dir,
                 '05_processed_alignments', '{}.metrics'.format(sample_id)))
             try:
-                synonymous_SNPs = 0
-                nonsynonymous_SNPs = 0
-
                 with open(os.path.realpath(picard_metrics_fn), 'r') as fh:
                     nextLine = False
                     for line in fh:
                         line = line.strip()
-
                         if nextLine is True:
                             parts = line.split("\t")
                             percentDup = float(parts[7])

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -194,7 +194,7 @@ class CommonReport(ngi_reports.common.BaseReport):
 
                         if line[:13] == 'Ts_Tv_ratio ,':
                             snpEff['TsTv_ratio'] = '{:.3f}'.format(float(line[14:]))
-                            
+
 
                         # ALTERNATIVE BLOCKS FOR OLDER VERSION OF SNPEFF
                         # Type, Total, Homo, Hetero
@@ -312,7 +312,7 @@ class CommonReport(ngi_reports.common.BaseReport):
             snpEFf_output_rel = os.path.join(plots_dir_rel, '{}_snpEff_effect'.format(sample_id))
             snpEFf_output = os.path.join(plots_dir, '{}_snpEff_effect'.format(sample_id))
             snpEff_plots.plot_snpEff(snpEFf_fn, snpEFf_output)
-            self.plots[sample_id]['snpEFf_plot'] = '{}_types'.format(snpEFf_output_rel)
+            self.plots[sample_id]['snpEFf_plot'] = '{}_regions'.format(snpEFf_output_rel)
 
 
 

--- a/ngi_reports/stockholm/ign_sample_report.py
+++ b/ngi_reports/stockholm/ign_sample_report.py
@@ -25,6 +25,7 @@ class Report(ign_sample_report.CommonReport):
         if proj is not None:
             self.info['recipient'] = proj.get('contact')
             self.project['prep'] = proj.get('details', {}).get('library_construction_method')
+            self.project['UPPMAXid'] = proj.get('uppnex_id')
 
             # Get sample fields from statusdb
             for sid in self.samples.iterkeys():

--- a/ngi_reports/stockholm/ign_sample_report.py
+++ b/ngi_reports/stockholm/ign_sample_report.py
@@ -12,6 +12,9 @@ class Report(ign_sample_report.CommonReport):
     # Initialise the report
     def __init__(self, config, LOG, working_dir, **kwargs):
 
+        # Set node
+        self.ngi_node = 'stockholm'
+
         # Initialise the parent class
         super(Report, self).__init__(config, LOG, working_dir, **kwargs)
 

--- a/ngi_reports/stockholm/project_summary.py
+++ b/ngi_reports/stockholm/project_summary.py
@@ -14,14 +14,14 @@ from ngi_reports.common import project_summary
 from statusdb.db import connections as statusdb
 
 class Report(project_summary.CommonReport):
-    
+
     ## initialize class and assign basic variables
     def __init__(self, config, LOG, working_dir, **kwargs):
-        
+
         # Initialise the parent class
         # This will grab info from the Piper XML files if found
         super(Report, self).__init__(config, LOG, working_dir, **kwargs)
-        
+
         # Project name - collect from the command line if we have it
         if kwargs.get('project') is not None:
             self.project_info['ngi_name'] = kwargs['project']
@@ -32,10 +32,10 @@ class Report(project_summary.CommonReport):
             except KeyError:
                 self.LOG.error("No project name found - please specify using '--project'")
                 raise KeyError("No project name found - please specify using '--project'")
-        
+
         # Report filename
         self.report_fn = "{}_project_summary".format(self.project_info['ngi_name'])
-        
+
         # Get connections to the databases in StatusDB
         self.LOG.info("Connecting to statusDB...")
         pcon = statusdb.ProjectSummaryConnection(**kwargs)
@@ -45,13 +45,13 @@ class Report(project_summary.CommonReport):
         scon = statusdb.SampleRunMetricsConnection(**kwargs)
         assert scon, "Could not connect to {} database in StatusDB".format("samples")
         self.LOG.info("...connected")
-        
+
         # Get the project from statusdb
         self.proj = pcon.get_entry(self.project_info['ngi_name'])
         if not self.proj:
             self.LOG.error("No such project '{}'".format(self.project_info['ngi_name']))
             raise KeyError
-            
+
         # Bail If the data source is not lims (old projects)
         if self.proj.get('source') != 'lims':
             self.LOG.error("The source for data for project {} is not LIMS.".format(self.project_info['ngi_name']))
@@ -71,12 +71,12 @@ class Report(project_summary.CommonReport):
         self.project_info['reference']['organism'] = self.organism_names.get(self.project_info['reference']['genome'], '')
         self.project_info['user_ID'] = self.proj_details.get('customer_project_reference')
         self.project_info['num_lanes'] = self.proj_details.get('sequence_units_ordered_(lanes)')
-        self.project_info['UPPMAX_id'] = kwargs.get('uppmax_id') if kwargs.get('uppmax_id') else self.proj.get('uppnex_id');
+        self.project_info['UPPMAX_id'] = kwargs.get('uppmax_id') if kwargs.get('uppmax_id') else self.proj.get('uppnex_id')
         self.project_info['UPPMAX_path'] = "/proj/{}/INBOX/{}".format(self.project_info['UPPMAX_id'], self.project_info['ngi_name'])
         self.project_info['ordered_reads'] = self.get_ordered_reads()
         self.project_info['best_practice'] = False if self.proj_details.get('best_practice_bioinformatics','No') == "No" else True
         self.project_info['status'] = "Sequencing done" if self.proj.get('project_summary', {}).get('all_samples_sequenced') else "Sequencing ongoing"
-        
+
         # Collect information about the sample preps
         for sample_id, sample in sorted(self.proj.get('samples', {}).iteritems()):
             self.LOG.info('Processing sample {}'.format(sample_id))
@@ -84,7 +84,7 @@ class Report(project_summary.CommonReport):
             self.samples_info[sample_id] = {'ngi_id': sample_id}
             self.samples_info[sample_id]['customer_name'] = sample.get('customer_name')
             self.samples_info[sample_id]['preps'] = {}
-            
+
             ## Get sample objects from statusdb
             s_ids = []
             for sample_run_doc in scon.get_project_sample(sample_id, sample_prj=self.project_info['ngi_name']):
@@ -92,7 +92,7 @@ class Report(project_summary.CommonReport):
                 self.samples_info[sample_id]['lane'] = sample_run_doc.get('lane')
                 self.samples_info[sample_id]['fc_name'] = sample_run_doc.get('name')
                 s_ids.append(sample_run_doc.get("_id"))
-            
+
             # Go through each prep in the Projects database
             for prep_id, prep in sample.get('library_prep', {}).iteritems():
                 for fc_name, lane in prep.get('sample_run_metrics', {}).iteritems():
@@ -112,25 +112,25 @@ class Report(project_summary.CommonReport):
                                 self.LOG.warn('Project DB sample_run_metrics document id {} for run {} not found in the samples database!'.format(doc_id, fc_name))
                         else:
                             self.LOG.warn("No sample_run_metrics document for run {} with id {} found in samples database!".format(fc_name, doc_id))
-            
+
             ## Warn if any aren't also mentioned in the statusdb project
             for s_id in s_ids:
                 self.LOG.error("sample_run_metrics document ({}) found for sample {} but no corresponding entry in project database. \
                          Please check for inconsistencies!".format(s_id, sample_id))
 
-                
-              
-        
 
-        
-        
-        
-        
-        
 
-        
-        
-        
+
+
+
+
+
+
+
+
+
+
+
     def get_ordered_reads(self):
         """ Get the minimum ordered reads for this project or return None
         """
@@ -146,8 +146,8 @@ class Report(project_summary.CommonReport):
             return ", ".join(list(set(reads_min)))
         else:
             return None
-    
-    
+
+
     def get_order_dates(self):
         """ Get order dates as a markdown string. Ignore if unavilable in status DB
         """
@@ -165,4 +165,3 @@ class Report(project_summary.CommonReport):
         if self.creation_date:
             dates.append("_Report date:_ {}".format(self.creation_date))
         return ", ".join(dates)
-    

--- a/ngi_reports/uppsala/ign_sample_report.py
+++ b/ngi_reports/uppsala/ign_sample_report.py
@@ -8,14 +8,19 @@ from ngi_reports.common import ign_sample_report
 from statusdb.db import connections as statusdb
 
 class Report(ign_sample_report.CommonReport):
-    
+
     # Initialise the report
     def __init__(self, config, LOG, working_dir, **kwargs):
-        
+
+        # Set node
+        self.ngi_node = 'uppsala'
+
         # Initialise the parent class
         super(Report, self).__init__(config, LOG, working_dir)
-        
+
         #### Missing Fields
         # self.info['recipient']
-        # self.sample['user_sample_id']
-        # self.sample['prep']
+        # self.project['prep']
+        # self.project['UPPMAXid']
+        # self.samples[sid]['user_sample_id']
+        # self.samples[sid]['barcode']

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -29,30 +29,7 @@ def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pand
     LOG.info('Report type: {}'.format(report_type))
 
     # Figure out the sequencing node
-    # Start with the command line variable that overwrites everything
-    if ngi_node == 'unknown':
-        # Get from the config file if we can
-        ngi_node = config.get('ngi_reports', 'ngi_node')
-        # Not found in the config, try to get from piper xml file
-        if ngi_node == 'unknown':
-            setup_dir = os.path.join(working_dir, 'setup_xml_files')
-            if os.path.isdir(setup_dir):
-                for file in os.listdir(setup_dir):
-                    if file.endswith(".xml"):
-                        try:
-                            with open(os.path.realpath(xml_fn)) as fh:
-                                raw_xml = xmltodict.parse(fh)
-                                seq_centre = raw_xml['project']['metadata']['sequenceingcenter']
-                                if seq_centre == 'NGI-S':
-                                    ngi_node = 'stockholm'
-                                elif uppmax_id == 'NGI-U':
-                                    ngi_node = 'uppsala'
-                        except IOError:
-                            pass
-
-    # We couldn't find it. Bail
-    if ngi_node == 'unknown':
-        raise "Could not determine sequencing node. Please pass this in with the "
+    ngi_node = find_ngi_node(ngi_node, working_dir)
 
     # Import the modules for this report type
     report_mod = __import__('ngi_reports.{}.{}'.format(ngi_node, report_type), fromlist=['ngi_reports.{}'.format(ngi_node)])
@@ -116,10 +93,55 @@ def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pand
     # Change back to previous working dir
     os.chdir(old_cwd)
 
+
+def find_ngi_node(ngi_node='unknown', working_dir=os.getcwd()):
+
+    # 1. Start with the command line variable that overwrites everything
+    if is_valid_ngi_node(ngi_node):
+        return ngi_node.lower()
+
+    # 2. Get from the config file if we can
+    # ngi_reports/common/config.py sets default var if missing to 'unknown'
+    ngi_node = config.get('ngi_reports', 'ngi_node')
+    if is_valid_ngi_node(ngi_node):
+        return ngi_node.lower()
+
+    # 3. Not found in the config, try to get from piper xml file
+    setup_dir = os.path.join(working_dir, 'setup_xml_files')
+    if os.path.isdir(setup_dir):
+        for file in os.listdir(setup_dir):
+            if file.endswith(".xml"):
+                try:
+                    with open(os.path.realpath(file)) as fh:
+                        raw_xml = xmltodict.parse(fh)
+                        seq_centre = raw_xml['project']['metadata']['sequenceingcenter']
+                        if seq_centre == 'NGI-S':
+                            if ngi_node == 'uppsala':
+                                raise RuntimeError ("Piper XML files contained both NGI-S and NGI-U fields. Please specify which with the --ngi_node parameter.")
+                            ngi_node = 'stockholm'
+                        elif uppmax_id == 'NGI-U':
+                            if ngi_node == 'stockholm':
+                                raise RuntimeError ("Piper XML files contained both NGI-S and NGI-U fields. Please specify which with the --ngi_node parameter.")
+                            ngi_node = 'uppsala'
+                except IOError:
+                    pass
+
+    if is_valid_ngi_node(ngi_node):
+        return ngi_node.lower()
+    else:
+        raise RuntimeError ("Could not determine sequencing node or node unrecognised: {} Please pass this in with the --ngi_node paramter.".format(ngi_node))
+
+def is_valid_ngi_node (ngi_node):
+    if ngi_node == 'stockholm' or ngi_node == 'uppsala':
+        return True
+    else:
+        return False
+
+
 # calling main method to generate report
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Make an NGI Report")
-    parser.add_argument("-n", "--node", dest="ngi_node", default='unknown',
+    parser.add_argument("-n", "--ngi_node", dest="ngi_node", default='unknown', choices=['unknown', 'stockholm', 'uppsala'],
         help="NGI Node. Default: attempts to find out from config file or setup XML files.")
     parser.add_argument("-d", "--dir", dest="working_dir", default=os.getcwd(),
         help="Working Directory. Default: cwd when script is executed.")

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -68,7 +68,8 @@ def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pand
             with open('{}.md'.format(output_bn), 'w') as fh:
                 print(output_md, file=fh)
         except IOError as e:
-            raise IOError(e)
+            LOG.error("Error printing markdown report {} - skipping. {}".format(output_md, IOError(e)))
+            continue
 
         # Set path to pandoc
         if pandoc_binary:

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -22,14 +22,39 @@ config = report_config.load_config()
 # create choices for report type based on available report template
 allowed_report_types = [ fl.replace(".md","") for fl in os.listdir(os.path.realpath(os.path.join(os.path.dirname(__file__), os.pardir, 'data', 'report_templates'))) ]
 
-def make_reports (report_type, working_dir=os.getcwd(), pandoc_binary=False, **kwargs):
+def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pandoc_binary=False, **kwargs):
 
     # Setup
     template_fn = '{}.md'.format(report_type)
     LOG.info('Report type: {}'.format(report_type))
 
+    # Figure out the sequencing node
+    # Start with the command line variable that overwrites everything
+    if ngi_node == 'unknown':
+        # Get from the config file if we can
+        ngi_node = config.get('ngi_reports', 'ngi_node')
+        # Not found in the config, try to get from piper xml file
+        if ngi_node == 'unknown':
+            setup_dir = os.path.join(working_dir, 'setup_xml_files')
+            if os.path.isdir(setup_dir):
+                for file in os.listdir(setup_dir):
+                    if file.endswith(".xml"):
+                        try:
+                            with open(os.path.realpath(xml_fn)) as fh:
+                                raw_xml = xmltodict.parse(fh)
+                                seq_centre = raw_xml['project']['metadata']['sequenceingcenter']
+                                if seq_centre == 'NGI-S':
+                                    ngi_node = 'stockholm'
+                                elif uppmax_id == 'NGI-U':
+                                    ngi_node = 'uppsala'
+                        except IOError:
+                            pass
+
+    # We couldn't find it. Bail
+    if ngi_node == 'unknown':
+        raise "Could not determine sequencing node. Please pass this in with the "
+
     # Import the modules for this report type
-    ngi_node = config.get('ngi_reports', 'ngi_node')
     report_mod = __import__('ngi_reports.{}.{}'.format(ngi_node, report_type), fromlist=['ngi_reports.{}'.format(ngi_node)])
 
     # Make the report object
@@ -94,6 +119,8 @@ def make_reports (report_type, working_dir=os.getcwd(), pandoc_binary=False, **k
 # calling main method to generate report
 if __name__ == "__main__":
     parser = argparse.ArgumentParser("Make an NGI Report")
+    parser.add_argument("-n", "--node", dest="ngi_node", default='unknown',
+        help="NGI Node. Default: attempts to find out from config file or setup XML files.")
     parser.add_argument("-d", "--dir", dest="working_dir", default=os.getcwd(),
         help="Working Directory. Default: cwd when script is executed.")
     parser.add_argument("-l", "--pandoc_binary", dest="pandoc_binary", action='store_true',


### PR DESCRIPTION
Fixed the missing fields and dodgy plot in the snpEff part of the report.

Realised that we can't rely on a config file to figure out which NGI node is running the report generation, as it's run on the `funk` account by both centres.

Still have the config file, but if the node isn't specified it tries to figure it out from the piper XML files. I also added a new command line option to specify it.