### PR TITLE
reports bugfixes

### DIFF
--- a/data/pandoc_templates/html_pandoc.html
+++ b/data/pandoc_templates/html_pandoc.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-  <link rel="shortcut icon" href="https://portal.scilifelab.se/genomics/sites/default/files/favicon_0.ico" type="image/vnd.microsoft.icon">
 $for(author-meta)$<meta name="author" content="$author-meta$">$endfor$
 $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
   <title>$if(subtitle)$$subtitle$ - $endif$$if(title)$$title$$endif$</title>
@@ -45,14 +44,14 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
   .center {
     text-align:center;
   }
-  
+
   blockquote {
     font-style:italic;
     padding-left:15px;
     margin-left:15px;
     border-left: 3px solid #CCCCCC;
   }
-  
+
   table {
     width:100%;
     border:1px solid #D9D9D9;
@@ -69,7 +68,7 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
   table p {
     margin:0;
   }
-  
+
   /* Ticks and Crosses */
   span.icon_tick {
     content: url(data:data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAEnQAABJ0BfDRroQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAADnSURBVDiNpZOvbgJBEIe/gRwCgSDUnMLVYcBUYYtA1eLoEyCoafDwBHgMD1BPcoqXwFWRENKKiuZyU7Mkk+lxHLDJiN2Z7zeZPyuqyj2ncgskIrWbBURkCnyLSCIiEapa2oAXQI09XwO3gaOBf4CHsnAEbF32V1XlFFAHHgsEFg5eGx8x8BUcK6Dq4AGQGXgHNKzAyKkvjTMG9sb3C/RcAprAwYnMwog37n3yr7yg8hS6aoMTd/8AJFcgiAyB1EEn+wRauQ129Yxz4BTon51QzsjeDZwBb4U7cmbuHWAOdC8tmdz7nf8A20hyYB2Q4kIAAAAASUVORK5CYII=);
@@ -162,7 +161,7 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
   }
   h1.title, h1.subtitle {
     font-weight: normal;
-    text-align: center; 
+    text-align: center;
     margin:0;
   }
   h1.title {
@@ -175,7 +174,7 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
   h3.date {
     display:none;
   }
-  
+
   .swedac {
     margin-top:30px;
   }
@@ -193,7 +192,7 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
     color:#999999;
     text-decoration:none;
   }
-  
+
   /***** Specific Report Types ******/
   #library-statistics dl dt, #variants dl dt {
     width: 200px;
@@ -202,7 +201,7 @@ $if(date-meta)$<meta name="dcterms.date" content="$date-meta$">$endif$
     text-align:right;
     margin-left:228px;
   }
-  
+
   </style>
   <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
@@ -252,4 +251,3 @@ $endif$
 </footer>
 </body>
 </html>
-

--- a/data/pandoc_templates/latex_pandoc.tex
+++ b/data/pandoc_templates/latex_pandoc.tex
@@ -223,20 +223,21 @@ $endif$
 \AtBeginEnvironment{description}{%
   \stepcounter{colordesc}%
   \begin{tikzpicture}[overlay,remember picture]
-  
+
   % Filled grey box over headers
-  \fill[gray!30] 
-    ( $$ (pic cs:start-\thecolordesc) + (-5pt,-1.85\topsep) $$ ) 
-      rectangle 
-    ( $$ ({pic cs:start-\thecolordesc}|-{pic cs:end-\thecolordesc}) + (\longestlabel-5pt,-.5\topsep) $$ );
-  
-  
+  % Looks nice, but breaks when we have page breaks. Disabling for now.
+  % \fill[gray!30]
+  %   ( $$ (pic cs:start-\thecolordesc) + (-5pt,-1.85\topsep) $$ )
+  %     rectangle
+  %   ( $$ ({pic cs:start-\thecolordesc}|-{pic cs:end-\thecolordesc}) + (\longestlabel-5pt,-.5\topsep) $$ );
+
+
   % Border along the right hand side of the definition list
-  \draw[gray!30] 
+  \draw[gray!30]
     ( $$ (current page text area.east|-{pic cs:start-\thecolordesc}) + (5pt,-1.85\topsep) $$ )
-      -- 
+      --
     ( $$ (current page text area.east|-{pic cs:end-\thecolordesc})  + (5pt,-0.45\topsep) $$ );
-  
+
   \end{tikzpicture}%
   \tikzmark{start-\thecolordesc}%
 }
@@ -247,14 +248,14 @@ $endif$
 % Border along the bottom of the definition list
 \AtEndEnvironment{description}{%
   \tikz[overlay,remember picture]\draw[gray!30]
-    ( $$ (current page text area.west|-{pic cs:end-\thecolordesc}) + (0,-.45\topsep) $$ ) 
+    ( $$ (current page text area.west|-{pic cs:end-\thecolordesc}) + (0,-.45\topsep) $$ )
     -- ++(1.01\textwidth,0);%
 }
 
 % Top borders of list items
 \renewcommand*\descriptionlabel[1]{%
   \tikz\draw[overlay,gray!30]
-    (-5pt,.8\baselineskip) -- 
+    (-5pt,.8\baselineskip) --
     (1.01\textwidth,.8\baselineskip);%
     \hspace\labelsep\normalfont\bfseries #1%
 }

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 
 """ Main module for dealing with fields for the IGN Sample Report
@@ -362,7 +363,7 @@ class CommonReport(ngi_reports.common.BaseReport):
                 self.plots[sample_id]['snpEFf_plot'] = '{}_regions'.format(snpEFf_output_rel)
 
             except IOError:
-                self.LOG.error('Required plotting files not found for {} - skipping sample..'.format(sample_id))
+                self.LOG.error('Error whilst plotting {} - skipping sample..'.format(sample_id))
 
 
 
@@ -373,36 +374,38 @@ class CommonReport(ngi_reports.common.BaseReport):
     def check_project_fields(self):
         """ Check that the object has all required fields. Returns True / False.
         """
+        missing_fields = []
         report_fields = []
         project_fields = ['id', 'sequencing_centre', 'sequencing_platform', 'ref_genome']
 
         for f in report_fields:
-            if not self.info.has_key(f):
-                self.LOG.error('Mandatory report field missing: {}'.format(f))
-                return False
+            if f not in self.info:
+                missing_fields.append(f)
         for f in project_fields:
-            if not self.project.has_key(f):
-                import json
-                print(json.dumps(self.project, indent=4))
-                self.LOG.error('Mandatory project field missing: {}'.format(f))
-                return False
+            if f not in self.project:
+                missing_fields.append(f)
+        if len(missing_fields) > 0:
+            self.LOG.error('Mandatory project-level field(s) missing: {}'.format(", ".join(missing_fields)))
+            return False
         return True
 
     def check_sample_fields(self, sample_id):
         """ Check that the object has all required fields. Returns True / False.
         """
+        missing_fields = []
         sample_fields = ['total_reads',  'percent_aligned', 'aligned_reads', 'median_insert_size',
             'automsomal_coverage', 'ref_above_30X', 'percent_gc']
         plot_fields = ['coverage_plot', 'cov_frac_plot', 'insert_size_plot', 'gc_dist_plot', 'snpEFf_plot']
 
         for f in sample_fields:
-            if not self.samples[sample_id].has_key(f):
-                self.LOG.error("Missing mandatory sample field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
-                return False
+            if f not in self.samples[sample_id]:
+                missing_fields.append(f)
         for f in plot_fields:
-            if not self.plots[sample_id].has_key(f):
-                self.LOG.error("Missing mandatory plot field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
-                return False
+            if f not in self.plots[sample_id]:
+                missing_fields.append(f)
+        if len(missing_fields) > 0:
+            self.LOG.error('Mandatory sample-level field(s) missing for {}: {}'.format(sample_id, ", ".join(missing_fields)))
+            return False
         return True
 
 

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -377,11 +377,11 @@ class CommonReport(ngi_reports.common.BaseReport):
         project_fields = ['id', 'sequencing_centre', 'sequencing_platform', 'ref_genome']
 
         for f in report_fields:
-            if f not in self.info.keys():
+            if not self.info.has_key(f):
                 self.LOG.error('Mandatory report field missing: {}'.format(f))
                 return False
         for f in project_fields:
-            if f not in self.project.keys():
+            if not self.project.has_key(f):
                 import json
                 print(json.dumps(self.project, indent=4))
                 self.LOG.error('Mandatory project field missing: {}'.format(f))
@@ -396,11 +396,11 @@ class CommonReport(ngi_reports.common.BaseReport):
         plot_fields = ['coverage_plot', 'cov_frac_plot', 'insert_size_plot', 'gc_dist_plot', 'snpEFf_plot']
 
         for f in sample_fields:
-            if f not in self.samples[sample_id].keys():
+            if not self.samples[sample_id].has_key(f):
                 self.LOG.error("Missing mandatory sample field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
                 return False
         for f in plot_fields:
-            if f not in self.plots[sample_id].keys():
+            if not self.plots[sample_id].has_key(f):
                 self.LOG.error("Missing mandatory plot field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
                 return False
         return True

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -47,14 +47,14 @@ class CommonReport(ngi_reports.common.BaseReport):
             raise IOError ('No samples found!')
 
         # Get more info from the filesystem
-        self.LOG.info('Parsing QC files')
+        self.LOG.debug('Parsing QC files')
         self.parse_qualimap()
         self.parse_snpeff()
         self.parse_picard_metrics()
 
         self.create_aggregate_statistics()
 
-        self.LOG.info('Plotting graphs')
+        self.LOG.debug('Plotting graphs')
         self.make_plots()
 
 
@@ -292,7 +292,7 @@ class CommonReport(ngi_reports.common.BaseReport):
         header = create_header(flattened_samples)
         rows = create_rows(flattened_samples)
 
-        self.LOG.info("Writing aggregate report to: " + output_file)
+        self.LOG.debug("Writing aggregate report to: " + output_file)
 
         # Drop it to a csv
         with open(output_file, 'wb') as csvfile:
@@ -397,11 +397,11 @@ class CommonReport(ngi_reports.common.BaseReport):
 
         for f in sample_fields:
             if f not in self.samples[sample_id].keys():
-                self.LOG.error('Mandatory sample field missing: {}'.format(f))
+                self.LOG.error("Missing mandatory sample field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
                 return False
         for f in plot_fields:
             if f not in self.plots[sample_id].keys():
-                self.LOG.error('Mandatory plot field missing: {}'.format(f))
+                self.LOG.error("Missing mandatory plot field '{}' for sample '{}'. Skipping sample.".format(f, sample_id))
                 return False
         return True
 
@@ -412,7 +412,7 @@ class CommonReport(ngi_reports.common.BaseReport):
 
         output_mds = {}
 
-        self.LOG.info('Processing reports')
+        self.LOG.debug('Processing reports')
 
         # Check that we have mandatory project-level fields
         if not self.check_project_fields():
@@ -422,15 +422,14 @@ class CommonReport(ngi_reports.common.BaseReport):
         # Go through each sample making the report
         for sample_id, sample in sorted(self.samples.iteritems()):
 
-            self.LOG.debug("Generating report for {}".format(sample_id)))
+            self.LOG.debug("Generating report for {}".format(sample_id))
 
             # Make the file basename
             report_fn = sample_id + '_ign_sample_report'
             output_bn = os.path.realpath(os.path.join(self.working_dir, self.report_dir, report_fn))
 
-            # check that we have everything
+            # check that we have everything (errors thrown by def)
             if not self.check_sample_fields(sample_id):
-                self.LOG.error("Missing mandatory sample-level fields for {} - skipping".format(sample_id))
                 continue
 
             # Parse the template

--- a/ngi_reports/common/ign_sample_report.py
+++ b/ngi_reports/common/ign_sample_report.py
@@ -308,54 +308,61 @@ class CommonReport(ngi_reports.common.BaseReport):
         """ Plot the visualizations for the IGN sample report
         """
         for sample_id in self.samples.iterkeys():
-            # Create plots sample dict
-            self.plots[sample_id] = {}
 
-            # Create the plots subdirectory
-            plots_dir_rel = os.path.join('plots', sample_id)
-            plots_dir = os.path.realpath(os.path.join(self.report_dir, plots_dir_rel))
-            if not os.path.exists(plots_dir):
-                os.makedirs(plots_dir)
+            # Avoid crashing the entire package for all samples if some files not found
+            try:
 
-            # Work out source directories
-            qualimap_raw_dir = os.path.realpath(os.path.join(self.working_dir, '06_final_alignment_qc',
-                '{}.clean.dedup.recal.qc'.format(sample_id), 'raw_data_qualimapReport'))
-            snpeff_data_dir = os.path.realpath(os.path.join(self.working_dir, '07_variant_calls'))
+                # Create plots sample dict
+                self.plots[sample_id] = {}
 
-            # Qualimap coverage plot
-            cov_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'coverage_histogram.txt'))
-            cov_output_rel = os.path.join(plots_dir_rel, '{}_coverage'.format(sample_id))
-            cov_output = os.path.join(plots_dir, '{}_coverage'.format(sample_id))
-            coverage_histogram.plot_coverage_histogram(cov_fn, cov_output)
-            self.plots[sample_id]['coverage_plot'] = cov_output_rel
+                # Create the plots subdirectory
+                plots_dir_rel = os.path.join('plots', sample_id)
+                plots_dir = os.path.realpath(os.path.join(self.report_dir, plots_dir_rel))
+                if not os.path.exists(plots_dir):
+                    os.makedirs(plots_dir)
 
-            # Qualimap genome fraction coverage plot
-            cov_frac_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'genome_fraction_coverage.txt'))
-            cov_frac_output_rel = os.path.join(plots_dir_rel, '{}_genome_fraction'.format(sample_id))
-            cov_frac_output = os.path.join(plots_dir, '{}_genome_fraction'.format(sample_id))
-            genome_fraction_coverage.plot_genome_fraction_coverage(cov_frac_fn, cov_frac_output)
-            self.plots[sample_id]['cov_frac_plot'] = cov_frac_output_rel
+                # Work out source directories
+                qualimap_raw_dir = os.path.realpath(os.path.join(self.working_dir, '06_final_alignment_qc',
+                    '{}.clean.dedup.recal.qc'.format(sample_id), 'raw_data_qualimapReport'))
+                snpeff_data_dir = os.path.realpath(os.path.join(self.working_dir, '07_variant_calls'))
 
-            # Qualimap insert size plot
-            insert_size_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'insert_size_histogram.txt'))
-            insert_size_output_rel = os.path.join(plots_dir_rel, '{}_insert_size'.format(sample_id))
-            insert_size_output = os.path.join(plots_dir, '{}_insert_size'.format(sample_id))
-            insert_size.plot_insert_size_histogram(insert_size_fn, insert_size_output)
-            self.plots[sample_id]['insert_size_plot'] = insert_size_output_rel
+                # Qualimap coverage plot
+                cov_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'coverage_histogram.txt'))
+                cov_output_rel = os.path.join(plots_dir_rel, '{}_coverage'.format(sample_id))
+                cov_output = os.path.join(plots_dir, '{}_coverage'.format(sample_id))
+                coverage_histogram.plot_coverage_histogram(cov_fn, cov_output)
+                self.plots[sample_id]['coverage_plot'] = cov_output_rel
 
-            # Qualimap GC distribution plot
-            gc_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'mapped_reads_gc-content_distribution.txt'))
-            gc_output_rel = os.path.join(plots_dir_rel, '{}_gc_distribution'.format(sample_id))
-            gc_output = os.path.join(plots_dir, '{}_gc_distribution'.format(sample_id))
-            gc_distribution.plot_genome_fraction_coverage(gc_fn, gc_output)
-            self.plots[sample_id]['gc_dist_plot'] = gc_output_rel
+                # Qualimap genome fraction coverage plot
+                cov_frac_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'genome_fraction_coverage.txt'))
+                cov_frac_output_rel = os.path.join(plots_dir_rel, '{}_genome_fraction'.format(sample_id))
+                cov_frac_output = os.path.join(plots_dir, '{}_genome_fraction'.format(sample_id))
+                genome_fraction_coverage.plot_genome_fraction_coverage(cov_frac_fn, cov_frac_output)
+                self.plots[sample_id]['cov_frac_plot'] = cov_frac_output_rel
 
-            # snpEff plot
-            snpEFf_fn = os.path.realpath(os.path.join(snpeff_data_dir, '{}.clean.dedup.recal.bam.raw.annotated.vcf.snpEff.summary.csv'.format(sample_id)))
-            snpEFf_output_rel = os.path.join(plots_dir_rel, '{}_snpEff_effect'.format(sample_id))
-            snpEFf_output = os.path.join(plots_dir, '{}_snpEff_effect'.format(sample_id))
-            snpEff_plots.plot_snpEff(snpEFf_fn, snpEFf_output)
-            self.plots[sample_id]['snpEFf_plot'] = '{}_regions'.format(snpEFf_output_rel)
+                # Qualimap insert size plot
+                insert_size_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'insert_size_histogram.txt'))
+                insert_size_output_rel = os.path.join(plots_dir_rel, '{}_insert_size'.format(sample_id))
+                insert_size_output = os.path.join(plots_dir, '{}_insert_size'.format(sample_id))
+                insert_size.plot_insert_size_histogram(insert_size_fn, insert_size_output)
+                self.plots[sample_id]['insert_size_plot'] = insert_size_output_rel
+
+                # Qualimap GC distribution plot
+                gc_fn = os.path.realpath(os.path.join(qualimap_raw_dir, 'mapped_reads_gc-content_distribution.txt'))
+                gc_output_rel = os.path.join(plots_dir_rel, '{}_gc_distribution'.format(sample_id))
+                gc_output = os.path.join(plots_dir, '{}_gc_distribution'.format(sample_id))
+                gc_distribution.plot_genome_fraction_coverage(gc_fn, gc_output)
+                self.plots[sample_id]['gc_dist_plot'] = gc_output_rel
+
+                # snpEff plot
+                snpEFf_fn = os.path.realpath(os.path.join(snpeff_data_dir, '{}.clean.dedup.recal.bam.raw.annotated.vcf.snpEff.summary.csv'.format(sample_id)))
+                snpEFf_output_rel = os.path.join(plots_dir_rel, '{}_snpEff_effect'.format(sample_id))
+                snpEFf_output = os.path.join(plots_dir, '{}_snpEff_effect'.format(sample_id))
+                snpEff_plots.plot_snpEff(snpEFf_fn, snpEFf_output)
+                self.plots[sample_id]['snpEFf_plot'] = '{}_regions'.format(snpEFf_output_rel)
+
+            except IOError:
+                self.LOG.error('Required plotting files not found for {} - skipping sample..'.format(sample_id))
 
 
 
@@ -374,22 +381,22 @@ class CommonReport(ngi_reports.common.BaseReport):
 
         for f in report_fields:
             if f not in self.info.keys():
-                self.LOG.error('Mandatory report field missing: '+f)
+                self.LOG.error('Mandatory report field missing: {}'.format(f))
                 return False
         for f in project_fields:
             if f not in self.project.keys():
                 import json
                 print(json.dumps(self.project, indent=4))
-                self.LOG.error('Mandatory project field missing: '+f)
+                self.LOG.error('Mandatory project field missing: {}'.format(f))
                 return False
         for sample_id in self.samples.iterkeys():
             for f in sample_fields:
                 if f not in self.samples[sample_id].keys():
-                    self.LOG.error('Mandatory sample field missing: '+f)
+                    self.LOG.error('Mandatory sample field missing: {}'.format(f))
                     return False
             for f in plot_fields:
                 if f not in self.plots[sample_id].keys():
-                    self.LOG.error('Mandatory plot field missing: '+f)
+                    self.LOG.error('Mandatory plot field missing: {}'.format(f))
                     return False
         return True
 

--- a/ngi_reports/stockholm/ign_sample_report.py
+++ b/ngi_reports/stockholm/ign_sample_report.py
@@ -19,7 +19,7 @@ class Report(ign_sample_report.CommonReport):
         super(Report, self).__init__(config, LOG, working_dir, **kwargs)
 
         # Get project fields from statusdb
-        self.LOG.info('Connecting to statusDB...')
+        self.LOG.debug('Connecting to statusDB...')
         pcon = statusdb.ProjectSummaryConnection()
         assert pcon, "Could not connect to project database in StatusDB"
         proj = pcon.get_entry(self.project['id'], use_id_view=True)

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -61,7 +61,7 @@ def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pand
     os.chdir(report.report_dir)
 
     # Get parsed markdown and print to file(s)
-    LOG.info('Converting markdown to HTML and PDF')
+    LOG.debug('Converting markdown to HTML and PDF')
     output_mds = report.parse_template(template)
     for output_bn, output_md in output_mds.iteritems():
         try:
@@ -79,7 +79,7 @@ def make_reports (report_type, ngi_node='unknown', working_dir=os.getcwd(), pand
 
         # Convert markdown to HTML using pandoc
         try:
-            html_cmd = shlex.split('{2} --standalone --section-divs {0}.md -o {0}.html --template={1}/html_pandoc.html --default-image-extension=png --filter {1}/pandoc_filters.py'.format(output_bn, pandoc_dir, pandoc_cmd))
+            html_cmd = shlex.split('{2} --standalone --self-contained --section-divs {0}.md -o {0}.html --template={1}/html_pandoc.html --default-image-extension=png --filter {1}/pandoc_filters.py'.format(output_bn, pandoc_dir, pandoc_cmd))
             subprocess.call(html_cmd)
         except OSError:
             LOG.error('Could not convert markdown to HTML - pandoc error. Skipping HTML report generation...')

--- a/setup.py
+++ b/setup.py
@@ -9,19 +9,20 @@ try:
 except IOError:
     install_requires = []
 
-setup(name='ngi_reports',
-      version=version,
-      description="Report generation for NGI Sweden",
-      long_description='This package is used to generate different types of '
-                       'reports for both the NGI Stockholm and Uppsala nodes.',
-      keywords='bioinformatics',
-      author='Phil Ewels',
-      author_email='phil.ewels@scilifelab.se',
-      url='https://portal.scilifelab.se/genomics/',
-      license='MIT',
-      packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-      include_package_data=True,
-      zip_safe=False,
-      scripts=['scripts/ngi_reports'],
-      install_requires=install_requires
-      )
+setup(
+    name='ngi_reports',
+    version=version,
+    description="Report generation for NGI Sweden",
+    long_description='This package is used to generate different types of '
+                   'reports for both the NGI Stockholm and Uppsala nodes.',
+    keywords='bioinformatics',
+    author='Phil Ewels',
+    author_email='phil.ewels@scilifelab.se',
+    url='https://portal.scilifelab.se/genomics/',
+    license='MIT',
+    packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
+    include_package_data=True,
+    zip_safe=False,
+    scripts=['scripts/ngi_reports'],
+    install_requires=install_requires
+)


### PR DESCRIPTION
- Fixed bug, missing fields in one sample now doesn't halt execution for _all_ samples
- PDF report no longer has filled grey boxes, so shouldn't get them overlapping content
- HTML report now has base64 encoded images, so can be shared as a single file (without the `plots) directory