### PR TITLE
changes to adapt TACA implementation for HiSeq2500

### DIFF
--- a/data/report_templates/project_summary.md
+++ b/data/report_templates/project_summary.md
@@ -181,18 +181,6 @@ reverse reads (if the run was a paired-end run).
 
 The naming of the files follow the convention:
 
-{% if not project.is_hiseqx -%}
-```
-[LANE]_[DATE]_[POSITION][FLOWCELL]_[NGI-NAME]_[READ].fastq.gz
-```
-
-* _LANE:_ Sequencing lane that the file originates from
-* _DATE:_ Date of sequencing
-* _POSITION:_ Position of the flowcell in the sequencer
-* _FLOWCELL:_ Unique flowcell indentifier
-* _NGI-NAME:_ Internal NGI sample indentifier
-* _READ:_ Forward(1) or reverse(2) read indentifier
-{%- else -%}
 ```
 [NGI-NAME]_[BCL-CONVERSION-ID]_[LANE]_[READ]_[VOLUME].fastq.gz
 ```
@@ -202,7 +190,6 @@ The naming of the files follow the convention:
 * _LANE:_ Sequencing lane that the file originates from
 * _READ:_ Forward(1) or reverse(2) read indentifier
 * _VOLUME:_ Volume index when file is large enough to be split into volumes
-{%- endif %}
 
 ## Data access at UPPMAX
 

--- a/data/report_templates/project_summary.md
+++ b/data/report_templates/project_summary.md
@@ -40,11 +40,13 @@ Ordered lanes
 Order Dates
 :   {{ project.dates }}
 
+{% if project.UPPMAX_id -%}
 UPPMAX Project ID
 :   `{{ project.UPPMAX_id }}`
 
 UPPNEX project path
 :   `{{ project.UPPMAX_path }}`
+{%- endif %}
 
 {% if project.reference.genome -%}
 Reference Genome

--- a/ngi_reports/__init__.py
+++ b/ngi_reports/__init__.py
@@ -1,3 +1,3 @@
 """ Main ngi_reports module
 """
-__version__="0.1.2"
+__version__="0.1.3"

--- a/ngi_reports/stockholm/project_summary.py
+++ b/ngi_reports/stockholm/project_summary.py
@@ -91,6 +91,9 @@ class Report(project_summary.CommonReport):
         self.project_info['UPPMAX_id'] = kwargs.get('uppmax_id') if kwargs.get('uppmax_id') else self.proj.get('uppnex_id','').lower()
         if not self.project_info['UPPMAX_id']:
             self.LOG.warn("UPPMAX id missing in status db, provide with option '-u' if known or contact project co-ordinater")
+        elif not re.match(r'^[a-b]\d{7}$', self.project_info['UPPMAX_id']):
+            self.LOG.warn("UPPMAX id '{}' is not in the expected formatted, so setting uppmax id as 'None' and will not be shown in the final report".format(self.project_info['UPPMAX_id']))
+            self.project_info['UPPMAX_id'] = None
         self.project_info['UPPMAX_path'] = "/proj/{}/INBOX/{}".format(self.project_info['UPPMAX_id'], self.project_info['ngi_name'])
         self.project_info['ordered_reads'] = []
         self.project_info['best_practice'] = False if self.proj_details.get('best_practice_bioinformatics','No') == "No" else True

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import subprocess
 
+from ngi_reports import __version__
 from ngi_reports.log import loggers
 from ngi_reports.utils import config as report_config
 
@@ -186,6 +187,7 @@ if __name__ == "__main__":
     parser.add_argument('--samples', default=None, action="store", nargs="*", help="Limit the samples to include in reports")
     parser.add_argument('--samples_extra', default={}, action="store", type=json.loads, help="Pass in extra information about samples as a json string, having each sample as a key. Example: --samples_extra '{\"TS001-1\": {\"delivered\": \"20150701\"}}'")
     parser.add_argument('--fc_phix', default={}, action="store", type=json.loads, help="Overwrite or use Phix values for mentioned flowcells/lanes provided as a json string, having each flowcell as a key. Example: --fc_phix '{\"BH3JLWCCXX\": {\"1\": \"0.42\", \"3\": \"0.46\"}}'")
+    parser.add_argument('--version', action='version', version="NGI reports version - {}".format(__version__))
     
     kwargs = vars(parser.parse_args())
 


### PR DESCRIPTION
As `TACA` was implemented for `HiSeq2500` as information to be fetched from have changed a little. Now info for all runs will be in `x_flowcells` (except the old runs). 

Since all runs are demultiplexed with same version of `bcl2fastq`, data from different instrument is going to have same naming convention. If report is generated for old projects (which should be very few), naming convention should be changed by hand in `.md` file. In a week or two there would not be any old project. 