### PR TITLE
handleing UPPMAX id

### DIFF
--- a/data/report_templates/project_summary.md
+++ b/data/report_templates/project_summary.md
@@ -195,6 +195,7 @@ The naming of the files follow the convention:
 * _VOLUME:_ Volume index when file is large enough to be split into volumes
 {%- endif %}
 
+{% if project.UPPMAX_id -%}
 ## Data access at UPPMAX
 
 Data from the sequencing will be uploaded to the UPPNEX (UPPMAX Next
@@ -210,6 +211,7 @@ If you have problems accessing your data, please contact NGI
 [{{ project.support_email }}](mailto:{{ project.support_email }}).
 If you have questions regarding UPPNEX, please contact
 [support@uppmax.uu.se](mailto:support@uppmax.uu.se).
+{%- endif %}
 
 ## Acknowledgements
 

--- a/ngi_reports/__init__.py
+++ b/ngi_reports/__init__.py
@@ -1,3 +1,3 @@
 """ Main ngi_reports module
 """
-__version__="0.1.6"
+__version__="0.1.7"

--- a/ngi_reports/stockholm/project_summary.py
+++ b/ngi_reports/stockholm/project_summary.py
@@ -92,8 +92,7 @@ class Report(project_summary.CommonReport):
         self.project_info['UPPMAX_id'] = kwargs.get('uppmax_id') if kwargs.get('uppmax_id') else self.proj.get('uppnex_id','').lower()
         if not self.project_info['UPPMAX_id']:
             self.LOG.warn("UPPMAX id missing in status db, provide with option '-u' if known or contact project co-ordinater")
-        elif not re.match(r'^[a-b]\d{7}$', self.project_info['UPPMAX_id']):
-            self.LOG.warn("UPPMAX id '{}' is not in the expected formatted, so setting uppmax id as 'None' and will not be shown in the final report".format(self.project_info['UPPMAX_id']))
+        elif "HDD" in self.project_info['UPPMAX_id']:
             self.project_info['UPPMAX_id'] = None
         self.project_info['UPPMAX_path'] = "/proj/{}/INBOX/{}".format(self.project_info['UPPMAX_id'], self.project_info['ngi_name'])
         self.project_info['ordered_reads'] = []


### PR DESCRIPTION
There is no expected `UPPMAX` id format anymore, now a days they are very varying. So it is better if we just catch the `HDD` deliveries (real intention behind the loop to begin with).