### PR TITLE
Added section about libraries failing QC

### DIFF
--- a/data/report_templates/project_summary.md
+++ b/data/report_templates/project_summary.md
@@ -150,6 +150,10 @@ NGI ID | User ID | Status
 
 # General Information
 
+## Libraries that have failed reception control QC
+
+In cases where libraries have failed the QC, the user is always contacted and asked how to proceed. If the user wishes to proceed to sequence the failed libraries, NGI bears no responsibility regarding the quality and number of reads of the sequenced sample data. In addition, the re-run policy does not apply.
+
 {% if not project.skip_fastq -%}
 ## Naming conventions
 


### PR DESCRIPTION
We need to add a section in the project report regarding cases where libraries fail the initial QC and the user still wants to continue the sequencing, in order to clarify that NGI doesn't guarantee the same results as for libraries that pass QC.