### PR TITLE
Make NBIS xml file generation an opt-in option

### DIFF
--- a/ngi_reports/stockholm/project_summary.py
+++ b/ngi_reports/stockholm/project_summary.py
@@ -369,7 +369,7 @@ class Report(project_summary.CommonReport):
     ######################################################
 
         self.xml_info = {}
-        if not kwargs.get('no_xml', False):
+        if not kwargs.get('xml', False):
             self.LOG.info("Fetching information for xml generation")
             try:
                 xgen = nbis_xml_generator.xml_generator(self.proj, # statusdb project object
@@ -381,7 +381,7 @@ class Report(project_summary.CommonReport):
                                                         xcon=xcon) # StatusDB xflowcells connection
                 self.xml_info.update(xgen.generate_xml(return_string_dict=True))
             except Exception as e:
-                self.LOG.warning("Fetching XML infroamtion failed due to '{}'".format(e))
+                self.LOG.warning("Fetching XML information failed due to '{}'".format(e))
 
 
     #####################################################

--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -179,7 +179,7 @@ if __name__ == "__main__":
     parser.add_argument('--skip_fastq', action="store_true", help="Option to skip naming convention of fastq files from report")
     parser.add_argument('--exclude_fc', nargs="*", default=[], action="store", help="Exclude these FCs while processing, Format should be BH3JLWCCXX/000000000-AEUUP.")
     parser.add_argument('--no_txt', action="store_true", help="Use this option to not generate TXT files for tables")
-    parser.add_argument('--no_xml', action="store_true", help="Use this option to not generate XML files for NBIS")
+    parser.add_argument('--xml', action="store_true", help="Use this option to generate XML files for NBIS for delivered projects")
     parser.add_argument('--ignore_lib_prep', action="store_true", help="Use this option to not consider lib preps while XML files generation")
     parser.add_argument('--samples', default=None, action="store", nargs="*", help="Limit the samples to include in reports")
     parser.add_argument('--samples_extra', default={}, action="store", type=json.loads, help="Pass in extra information about samples as a json string, having each sample as a key. Example: --samples_extra '{\"TS001-1\": {\"delivered\": \"20150701\"}}'")


### PR DESCRIPTION
NBIS xml files can only be generated for projects that are already delivered, so this makes it an opt-in rather than generating them by default. 