### PR TITLE
Add shorter config option for markdown file

### DIFF
--- a/scripts/ngi_reports
+++ b/scripts/ngi_reports
@@ -139,7 +139,7 @@ if __name__ == "__main__":
     parser.add_argument('--samples_extra', default={}, action="store", type=json.loads, help="Pass in extra information about samples as a json string, having each sample as a key. Example: --samples_extra '{\"TS001-1\": {\"delivered\": \"20150701\"}}'")
     parser.add_argument('--fc_phix', default={}, action="store", type=json.loads, help="Overwrite or use Phix values for mentioned flowcells/lanes provided as a json string, having each flowcell as a key. Example: --fc_phix '{\"BH3JLWCCXX\": {\"1\": \"0.42\", \"3\": \"0.46\"}}'")
     parser.add_argument('--version', action='version', version="NGI reports version - {}".format(__version__))
-    parser.add_argument('--markdown_file', default=None, help="Regenerate the html report from the given markdown file")
+    parser.add_argument('-md', '--markdown_file', default=None, help="Regenerate the html report from the given markdown file")
 
     kwargs = vars(parser.parse_args())
 


### PR DESCRIPTION
In this new version of ngi_reports, we are doing away with the `make_report` script because the package has been simplified in how it generates reports. The new way to generate a report from an existing md file from the next deployment on would be 

`ngi_reports project_summary -md <name_of_md_file>`

Do comment if you guys think its too long, I can add an alias for this in irma-provision.