### PR TITLE
Revert "Fix bug with the read counts for NextSeq 2000"

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,8 +1,5 @@
 # ngi_reports Version Log
 
-## 20210407.1
-Fix bug with the read counts for NextSeq 2000
-
 ## 20210319.2
 Fix bug with seq_software of NextSeq2000
 

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -391,7 +391,7 @@ class Project:
                     lane_sum = fc_lane_summary.get(lane, fc_lane_summary.get('A',{}))
                     laneObj.id = lane
                     laneObj.set_lane_info('cluster', 'Reads PF (M)' if 'NovaSeq' in fcObj.type or 'NextSeq' in fcObj.type else 'Clusters PF', lane_sum,
-                                                str(r_num), False if 'NovaSeq' in fcObj.type else True)
+                                                str(r_num), False if 'NovaSeq' in fcObj.type or 'NextSeq' in fcObj.type else True)
                     laneObj.set_lane_info('avg_qval', '% Bases >=Q30', lane_sum, str(r_num))
                     laneObj.set_lane_info('fc_phix', '% Error Rate', lane_sum, str(r_num))
                     if kwargs.get('fc_phix',{}).get(fcObj.name, {}):


### PR DESCRIPTION
Reverts NationalGenomicsInfrastructure/ngi_reports#131

The PR was wrongly placed because a wrong value was filled in LIMS, so that the value in report was affected. Sorry!