### PR TITLE
ngi_reports to deal with re-demultiplexed flow-cells

### DIFF
--- a/ngi_reports/ngi_reports.py
+++ b/ngi_reports/ngi_reports.py
@@ -140,7 +140,7 @@ def main():
     parser.add_argument('--fc_phix', default={}, action="store", type=json.loads, help="Overwrite or use Phix values for mentioned flowcells/lanes provided as a json string, having each flowcell as a key. Example: --fc_phix '{\"BH3JLWCCXX\": {\"1\": \"0.42\", \"3\": \"0.46\"}}'")
     parser.add_argument('--version', action='version', version="NGI reports version - {}".format(__version__))
     parser.add_argument('-md', '--markdown_file', default=None, help="Regenerate the html report from the given markdown file")
-    parser.add_argument('-b', '--barcode_from_fc', default=False, action="store_true", help="retrived the index from the FC directly")
+    parser.add_argument('-b', '--barcode_from_fc', default=False, action="store_true", help="retrieve the index from the FC directly")
 
     kwargs = vars(parser.parse_args())
 

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 from collections import defaultdict, OrderedDict
 from datetime import datetime
+import pdb
 
 from ngi_reports.utils import statusdb
 
@@ -273,7 +274,8 @@ class Project:
 
             # exception for case of multi-barcoded sample from different preps run on the same fc (only if -b flag is set)
             if kwargs.get('barcode_from_fc'):
-                list_of_barcodes = sum([all_barcodes.barcode for all_barcodes in list(samObj.preps.values())], [])
+            #    pdb.set_trace()
+                list_of_barcodes = sum([[all_barcodes.barcode for all_barcodes in list(samObj.preps.values())]], [])
                 if len(list(dict.fromkeys(list_of_barcodes))) >= 1:
                     list_of_flowcells = sum([all_flowcells.seq_fc for all_flowcells in list(samObj.preps.values())], [])
                     if len(list_of_flowcells) != len(list(dict.fromkeys(list_of_flowcells))):               #the sample was run twice on the same flowcell, only possible with different barcodes for the same sample
@@ -385,9 +387,10 @@ class Project:
                             continue
                 
                 ## get (if any) samples that are on the fc, but are not recorded in LIMS (i.e. added bc from undet reads)
-                if list(self.samples) != fc_samples:
+                if len(set(list(self.samples))) != len(set(fc_samples)):
                     list_additional_samples = list(set(fc_samples) - set(self.samples))
                     list_additional_samples.sort()              # generate a list of all additional samples
+                   # pdb.set_trace()
                     log.info('The flowcell {} contains {} sample(s) ({}) that has/have not been defined in LIMS. They will be added to the report.'.format(fc_details.get('RunInfo').get('Id'), len(list_additional_samples), ', '.join(list_additional_samples)))
 
                     undet_iteration = 1

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -378,7 +378,8 @@ class Project:
                 ## itterate through all samples in project to identify their prep_ID (only if they are on the flowcell)
                 for sample_ID in list(self.samples):
                      for prep_ID in list(self.samples.get(sample_ID).preps):
-                        if fcObj.name in self.samples.get(sample_ID).preps.get(prep_ID).seq_fc:
+                        sample_preps = self.samples.get(sample_ID).preps
+                        if fcObj.name in sample_preps.get(prep_ID).seq_fc:
                             preps_samples_on_fc.append([sample_ID, prep_ID])
                         else:
                             continue

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -5,7 +5,6 @@ import sys
 import numpy as np
 from collections import defaultdict, OrderedDict
 from datetime import datetime
-import pdb
 
 from ngi_reports.utils import statusdb
 
@@ -274,7 +273,6 @@ class Project:
 
             # exception for case of multi-barcoded sample from different preps run on the same fc (only if -b flag is set)
             if kwargs.get('barcode_from_fc'):
-            #    pdb.set_trace()
                 list_of_barcodes = sum([[all_barcodes.barcode for all_barcodes in list(samObj.preps.values())]], [])
                 if len(list(dict.fromkeys(list_of_barcodes))) >= 1:
                     list_of_flowcells = sum([all_flowcells.seq_fc for all_flowcells in list(samObj.preps.values())], [])
@@ -377,7 +375,7 @@ class Project:
                     if fc_sample.get('Sample_Name').split('_')[0] == self.ngi_id:
                         fc_samples.append(fc_sample.get('Sample_Name'))
                 
-                ## itterate through all samples in project to identify their prep_ID (only if they are on the flowcell)
+                ## iterate through all samples in project to identify their prep_ID (only if they are on the flowcell)
                 for sample_ID in list(self.samples):
                      for prep_ID in list(self.samples.get(sample_ID).preps):
                         sample_preps = self.samples.get(sample_ID).preps
@@ -390,7 +388,6 @@ class Project:
                 if len(set(list(self.samples))) != len(set(fc_samples)):
                     list_additional_samples = list(set(fc_samples) - set(self.samples))
                     list_additional_samples.sort()              # generate a list of all additional samples
-                   # pdb.set_trace()
                     log.info('The flowcell {} contains {} sample(s) ({}) that has/have not been defined in LIMS. They will be added to the report.'.format(fc_details.get('RunInfo').get('Id'), len(list_additional_samples), ', '.join(list_additional_samples)))
 
                     undet_iteration = 1

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -1,12 +1,10 @@
 """ Define various entities and populate them
 """
-from pickle import FALSE
 import re
 import sys
 import numpy as np
 from collections import defaultdict, OrderedDict
 from datetime import datetime
-import pdb
 
 from ngi_reports.utils import statusdb
 
@@ -275,10 +273,10 @@ class Project:
 
             # exception for case of multi-barcoded sample from different preps run on the same fc (only if -b flag is set)
             if kwargs.get('barcode_from_fc'):
-                listOfBarcodes = sum([all_barcodes.barcode for all_barcodes in list(samObj.preps.values())], [])
-                if len(list(dict.fromkeys(listOfBarcodes))) >= 1:
-                    listOfFlowcells = sum([all_flowcells.seq_fc for all_flowcells in list(samObj.preps.values())], [])
-                    if len(listOfFlowcells) != len(list(dict.fromkeys(listOfFlowcells))):               #the sample was run twice on the same flowcell, only possible with different barcodes for the same sample
+                list_of_barcodes = sum([all_barcodes.barcode for all_barcodes in list(samObj.preps.values())], [])
+                if len(list(dict.fromkeys(list_of_barcodes))) >= 1:
+                    list_of_flowcells = sum([all_flowcells.seq_fc for all_flowcells in list(samObj.preps.values())], [])
+                    if len(list_of_flowcells) != len(list(dict.fromkeys(list_of_flowcells))):               #the sample was run twice on the same flowcell, only possible with different barcodes for the same sample
                         log.error('Ambiguous preps for barcodes on flowcell. Please run ngi_pipelines without the -b flag and amend the report manually')
                         sys.exit('Stopping execution...')
 
@@ -392,14 +390,14 @@ class Project:
                     additional_sample_on_fc = True
                     list_additional_samples = list(set(fc_samples) - set(self.samples))
                     list_additional_samples.sort()              # generate a list of all additional samples
-                    log.info('The flowcell {} containes {} sample(s) ({}) that has/have not been defined in LIMS. They will be added to the report.'.format(fc_details.get('RunInfo').get('Id'), len(list_additional_samples), ', '.join(list_additional_samples)))
+                    log.info('The flowcell {} contains {} sample(s) ({}) that has/have not been defined in LIMS. They will be added to the report.'.format(fc_details.get('RunInfo').get('Id'), len(list_additional_samples), ', '.join(list_additional_samples)))
 
-                    undet_itteration = 1
+                    undet_iteration = 1
                     # creating additional sample and prep Objects 
                     for additional_sample in list_additional_samples:
                         AsamObj               = Sample()
                         AsamObj.ngi_id        = additional_sample
-                        AsamObj.customer_name = 'unknown' + str(undet_itteration) # additional samples will be named "unknown[number]" in the report
+                        AsamObj.customer_name = 'unknown' + str(undet_iteration) # additional samples will be named "unknown[number]" in the report
                         AsamObj.well_location = 'NA'
                         AprepObj              = Prep()
                         AprepObj.label        = 'NA'
@@ -407,7 +405,7 @@ class Project:
                         AsamObj.preps['NA'] = AprepObj
                         self.samples[additional_sample] = AsamObj
                         preps_samples_on_fc.append([additional_sample, 'NA'])
-                        undet_itteration+=1
+                        undet_iteration+=1
                                 
             ## Collect quality info for samples and collect lanes of interest
             for stat in fc_details.get('illumina',{}).get('Demultiplex_Stats',{}).get('Barcode_lane_statistics',[]):

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -385,10 +385,7 @@ class Project:
                             continue
                 
                 ## get (if any) samples that are on the fc, but are not recorded in LIMS (i.e. added bc from undet reads)
-                if list(self.samples) == fc_samples:
-                    additional_sample_on_fc = False
-                else:
-                    additional_sample_on_fc = True
+                if list(self.samples) != fc_samples:
                     list_additional_samples = list(set(fc_samples) - set(self.samples))
                     list_additional_samples.sort()              # generate a list of all additional samples
                     log.info('The flowcell {} contains {} sample(s) ({}) that has/have not been defined in LIMS. They will be added to the report.'.format(fc_details.get('RunInfo').get('Id'), len(list_additional_samples), ', '.join(list_additional_samples)))
@@ -400,10 +397,8 @@ class Project:
                         AsamObj.ngi_id        = additional_sample
                         AsamObj.customer_name = 'unknown' + str(undet_iteration) # additional samples will be named "unknown[number]" in the report
                         AsamObj.well_location = 'NA'
-                        AprepObj              = Prep()
-                        AprepObj.label        = 'NA'
-
-                        AsamObj.preps['NA'] = AprepObj
+                        AsamObj.preps['NA'] = Prep()
+                        AsamObj.preps['NA'].label = 'NA'
                         self.samples[additional_sample] = AsamObj
                         preps_samples_on_fc.append([additional_sample, 'NA'])
                         undet_iteration+=1


### PR DESCRIPTION
using a -b flag when creating the report will take the information of indexes from the flow cell instead of LIMS.