### PR TITLE
Change ONT lane info yield to only passed reads

### DIFF
--- a/VERSIONLOG.md
+++ b/VERSIONLOG.md
@@ -1,5 +1,8 @@
 # ngi_reports Version Log
 
+## 20260507.1
+Changed lane yield to only passed reads for ONT runs
+
 ## 20260424.1
 Bugfix to include all runs of a project, covering for ONT reruns
 

--- a/ngi_reports/reports/ont_project_summary.py
+++ b/ngi_reports/reports/ont_project_summary.py
@@ -123,7 +123,7 @@ class Report(ngi_reports.reports.project_summary.Report):
         self.tables_info["header_explanation"]["lanes_info"] = (
             "* _Date:_ Date of sequencing\n"
             "* _Flowcell:_ Flowcell identifier\n"
-            "* _Reads (M):_ Number of reads generated (million)\n"
+            "* _Reads (M):_ Number of passed reads generated (million)\n"
             "* _N50:_ Estimated N50\n"
             "* _Method:_ Sequencing method used. See description under Sequencing heading above.\n"
         )

--- a/ngi_reports/utils/entities.py
+++ b/ngi_reports/utils/entities.py
@@ -442,7 +442,7 @@ class Flowcell:
         yield_summary = final_acquisition.get("acquisition_run_info").get(
             "yield_summary"
         )
-        self.total_reads = round(float(yield_summary.get("read_count")) / 1000000, 2)
+        self.total_reads = round(float(yield_summary.get("basecalled_pass_read_count")) / 1000000, 2)
 
         ont_seq_versions = fc_runparameters.get("software_versions", "")
         self.seq_software = {


### PR DESCRIPTION
Change the read count from all reads generated to only passed reads for ONT runs. 